### PR TITLE
Add two single-node models to test ONNX's sequence outputs

### DIFF
--- a/Microsoft.ML.Onnx.TestModels/zipmap/TestZipMapInt64.onnx
+++ b/Microsoft.ML.Onnx.TestModels/zipmap/TestZipMapInt64.onnx
@@ -1,0 +1,16 @@
+:
+J
+inputoutputZipMap"ZipMap*
+classlabels_int64s@^@@$ :
+ai.onnx.mlZipMapInt64TestZ
+input
+
+
+b
+output"
+
+*
+B
+B
+
+ai.onnx.ml

--- a/Microsoft.ML.Onnx.TestModels/zipmap/TestZipMapString.onnx
+++ b/Microsoft.ML.Onnx.TestModels/zipmap/TestZipMapString.onnx
@@ -1,0 +1,17 @@
+:è
+N
+inputoutputZipMap"ZipMap*!
+classlabels_stringsJAJBJC†:
+ai.onnx.ml
+ZipMapTestZ
+input
+
+
+b
+output"
+
+*
+B
+B
+
+ai.onnx.ml


### PR DESCRIPTION
As title. This change is required in https://github.com/dotnet/machinelearning/pull/3881. 